### PR TITLE
Make explanations available as a file output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
         if: ${{ always() && steps.generatePatch.outputs.patchFilePath != '' && steps.diff.outputs.hasExplanations != '' && github.event_name == 'pull_request' }}
         continue-on-error: true
         with:
-          comment: ${{ steps.diff.outputs.explanations }}
+          comment: ${{ steps.diff.outputs.explanationsFilePath }}
           prNumber: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload patch file as artifact

--- a/README.md
+++ b/README.md
@@ -53,4 +53,11 @@ jobs:
         with:
           name: patch
           path: '*.patch'
+      - name: Upload explanations file as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: explanations
+          path: 'explanations.txt'
 ```

--- a/comment/action.yml
+++ b/comment/action.yml
@@ -6,7 +6,7 @@ branding:
 inputs:
   comment:
     description:
-      'Comment to post'
+      'Comment to post. This can be comment text or a path to a file containing the comment text.'
     required: true
   prNumber:
     description:

--- a/comment/clearOldComments.ps1
+++ b/comment/clearOldComments.ps1
@@ -7,4 +7,9 @@ foreach($comment in $comments) {
     gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "/repos/$($Env:GITHUB_REPOSITORY)/issues/comments/$($comment.id)"
 }
 
-gh pr comment $Env:PR_NUMBER -b "<!--publicapi-->$Env:COMMENT"
+$comment = $Env:COMMENT;
+if(Test-Path $Env:COMMENT) {# If the comment is a file path, read the content
+    $comment = Get-Content $Env:COMMENT
+}
+
+gh pr comment $Env:PR_NUMBER -b "<!--publicapi-->$comment"

--- a/tool/action.yml
+++ b/tool/action.yml
@@ -24,6 +24,9 @@ outputs:
   hasExplanations:
     description:
       'Boolean to indicate if there are any explanations'
+  explanationsFilePath:
+    description:
+      'The path to the file containing the explanations of the differences between the two Kiota DOM exports.'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/tool/src/ExplainDiffHandler.cs
+++ b/tool/src/ExplainDiffHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.CommandLine;
+using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Text;
 using Microsoft.Extensions.Logging;
@@ -82,6 +82,12 @@ internal class ExplainDiffHandler : ICommandHandler
         var directory = Directory.GetCurrentDirectory();
         var explanationFilePath = System.IO.Path.Combine(directory, "explanations.txt");
         await File.WriteAllTextAsync(explanationFilePath, explanationResult).ConfigureAwait(false);
+        var githubOutputFile = Environment.GetEnvironmentVariable("GITHUB_OUTPUT", EnvironmentVariableTarget.Process);
+        if (!string.IsNullOrWhiteSpace(githubOutputFile))
+        {
+            using var textWriter = new StreamWriter(githubOutputFile!, true, Encoding.UTF8);
+            await textWriter.WriteLineAsync($"explanationsFilePath={explanationFilePath}").ConfigureAwait(false);
+        }
     }
     private static async Task WriteSummaryToGitHubOutput(Difference[] results)
     {

--- a/tool/src/ExplainDiffHandler.cs
+++ b/tool/src/ExplainDiffHandler.cs
@@ -66,7 +66,8 @@ internal class ExplainDiffHandler : ICommandHandler
             }
             var explanationResult = sb.ToString();
             Console.WriteLine(explanationResult);
-            await WriteToGitHubOutput(result).ConfigureAwait(false);
+            await WriteExplanationToFileAsync(explanationResult).ConfigureAwait(false);
+            await WriteSummaryToGitHubOutput(result).ConfigureAwait(false);
 
             if (Array.Exists(result, static x => x.Kind is DifferenceKind.Removal) && failOnRemovalValue)
             {
@@ -76,7 +77,13 @@ internal class ExplainDiffHandler : ICommandHandler
             return 0;
         }
     }
-    private static async Task WriteToGitHubOutput(Difference[] results)
+    private static async Task WriteExplanationToFileAsync(string explanationResult)
+    {
+        var directory = Directory.GetCurrentDirectory();
+        var explanationFilePath = System.IO.Path.Combine(directory, "explanations.txt");
+        await File.WriteAllTextAsync(explanationFilePath, explanationResult).ConfigureAwait(false);
+    }
+    private static async Task WriteSummaryToGitHubOutput(Difference[] results)
     {
         // https://docs.github.com/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
         // ::set-output deprecated as mentioned in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

--- a/tool/src/ExplainDiffHandler.cs
+++ b/tool/src/ExplainDiffHandler.cs
@@ -59,6 +59,8 @@ internal class ExplainDiffHandler : ICommandHandler
                 diffValue = await File.ReadAllTextAsync(pathValue, cancellationToken).ConfigureAwait(false);
             }
             var result = diffExplanationService.ExplainDiff(diffValue);
+            var removalCount = result.Count(static x => x.Kind is DifferenceKind.Removal); // number of removals
+            var additionCount = result.Count(static x => x.Kind is DifferenceKind.Addition);// number of additions
             var sb = new StringBuilder();
             foreach (var diff in result)
             {
@@ -66,8 +68,8 @@ internal class ExplainDiffHandler : ICommandHandler
             }
             var explanationResult = sb.ToString();
             Console.WriteLine(explanationResult);
-            await WriteExplanationToFileAsync(explanationResult).ConfigureAwait(false);
-            await WriteSummaryToGitHubOutput(result).ConfigureAwait(false);
+            var explanationFilePath = await WriteExplanationToFileAsync(explanationResult).ConfigureAwait(false);
+            await WriteSummaryToGitHubOutput(removalCount, additionCount, explanationFilePath).ConfigureAwait(false);
 
             if (Array.Exists(result, static x => x.Kind is DifferenceKind.Removal) && failOnRemovalValue)
             {
@@ -77,25 +79,18 @@ internal class ExplainDiffHandler : ICommandHandler
             return 0;
         }
     }
-    private static async Task WriteExplanationToFileAsync(string explanationResult)
+    private static async Task<string> WriteExplanationToFileAsync(string explanationResult)
     {
         var directory = Directory.GetCurrentDirectory();
         var explanationFilePath = System.IO.Path.Combine(directory, "explanations.txt");
         await File.WriteAllTextAsync(explanationFilePath, explanationResult).ConfigureAwait(false);
-        var githubOutputFile = Environment.GetEnvironmentVariable("GITHUB_OUTPUT", EnvironmentVariableTarget.Process);
-        if (!string.IsNullOrWhiteSpace(githubOutputFile))
-        {
-            using var textWriter = new StreamWriter(githubOutputFile!, true, Encoding.UTF8);
-            await textWriter.WriteLineAsync($"explanationsFilePath={explanationFilePath}").ConfigureAwait(false);
-        }
+        return explanationFilePath;
     }
-    private static async Task WriteSummaryToGitHubOutput(Difference[] results)
+    private static async Task WriteSummaryToGitHubOutput(int removalCount, int additionCount, string explanationFilePath)
     {
         // https://docs.github.com/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
         // ::set-output deprecated as mentioned in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
         var githubOutputFile = Environment.GetEnvironmentVariable("GITHUB_OUTPUT", EnvironmentVariableTarget.Process);
-        var removalCount = results.Count(static x=> x.Kind is DifferenceKind.Removal);
-        var additionCount = results.Count(static x => x.Kind is DifferenceKind.Addition);
         if (!string.IsNullOrWhiteSpace(githubOutputFile))
         {
             using var textWriter = new StreamWriter(githubOutputFile!, true, Encoding.UTF8);
@@ -114,6 +109,7 @@ internal class ExplainDiffHandler : ICommandHandler
             }
             await textWriter.WriteLineAsync("EOF").ConfigureAwait(false);
             await textWriter.WriteLineAsync("hasExplanations=true").ConfigureAwait(false);
+            await textWriter.WriteLineAsync($"explanationsFilePath={explanationFilePath}").ConfigureAwait(false);
         }
     }
     protected (ILoggerFactory, ILogger<T>) GetLoggerAndFactory<T>(InvocationContext context, string logFileRootPath = "")


### PR DESCRIPTION
This PR makes the following changes to the actions

- Enables the comment actions to take in `filepaths` as opposed to comment text only. If the path is not a valid path, the action will assume the value is text an display it. This is done to avoid passing explanation text directly leading to crashing actions. (Note: a very large file will still be rejected by the GH Api due to comment length restrictions i.e[ `65,536` characters](https://github.com/orgs/community/discussions/27190))
- updates the `tool` action to also have an output that is a file of the explanations. (This can be uploaded as an artifact or the path used a comment in the comment action)